### PR TITLE
Support Oblivious Proxy function in ODoH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 [features]
 default = ["tls"]
 tls = ["libdoh/tls"]
+odoh-proxy = ["libdoh/odoh-proxy"]
 
 [dependencies]
 libdoh = { path = "src/libdoh", version = "0.9.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ cargo install doh-proxy
 cargo install doh-proxy --no-default-features
 ```
 
+* With Oblivious DoH Proxy function (**for testing pupose**):
+
+```sh
+cargo install doh-proxy --features=doh-proxy
+```
+
 ## Usage
 
 ```text
@@ -113,9 +119,11 @@ Unless the front-end is a CDN, an ideal setup is to use `doh-proxy` behind `Encr
 
 Oblivious DoH is similar to Anonymized DNSCrypt, but for DoH. It requires relays, but also upstream DoH servers that support the protocol.
 
-This proxy supports ODoH termination out of the box and relaying.
+This proxy supports ODoH termination out of the box.
 
 However, ephemeral keys are currently only stored in memory. In a load-balanced configuration, sticky sessions must be used.
+
+This also also provides ODoH relaying (Oblivious Proxy) of naive implementation, which is **for testing purposes only**. Please do not deploy the relaying function AS-IS. You need to carefully consider the performance and security issues when you deploy ODoH relays. Further, the relaying protocol is not fully fixed yet in the IETF draft.
 
 As currently available ODoH relays only use `POST` queries, this proxy accepts and issues `POST` queries both in ODoH target and relay functions.
 So, `POST` queries have been disabled for regular DoH queries, accepting them is required to be compatible with ODoH relays.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ USAGE:
     doh-proxy [FLAGS] [OPTIONS]
 
 FLAGS:
-    -O, --allow-odoh-post      Allow POST queries over ODoH even with they have been disabed for DoH
+    -O, --allow-odoh-post      Allow POST queries over ODoH even if they have been disabled for DoH
     -K, --disable-keepalive    Disable keepalive
     -P, --disable-post         Disable POST queries
     -h, --help                 Prints help information
@@ -48,6 +48,7 @@ OPTIONS:
     -C, --max-concurrent <max_concurrent>            Maximum number of concurrent requests per client [default: 16]
     -X, --max-ttl <max_ttl>                          Maximum TTL, in seconds [default: 604800]
     -T, --min-ttl <min_ttl>                          Minimum TTL, in seconds [default: 10]
+    -q, --odoh-proxy-path <odoh_proxy_path>          ODoH proxy URI path [default: /proxy]
     -p, --path <path>                                URI path [default: /dns-query]
     -g, --public-address <public_address>            External IP address DoH clients will connect to
     -u, --server-address <server_address>            Address to connect to [default: 9.9.9.9:53]
@@ -112,11 +113,11 @@ Unless the front-end is a CDN, an ideal setup is to use `doh-proxy` behind `Encr
 
 Oblivious DoH is similar to Anonymized DNSCrypt, but for DoH. It requires relays, but also upstream DoH servers that support the protocol.
 
-This proxy supports ODoH termination (not relaying) out of the box.
+This proxy supports ODoH termination out of the box and relaying.
 
 However, ephemeral keys are currently only stored in memory. In a load-balanced configuration, sticky sessions must be used.
 
-Currently available ODoH relays only use `POST` queries.
+As currently available ODoH relays only use `POST` queries, this proxy accepts and issues `POST` queries both in ODoH target and relay functions.
 So, `POST` queries have been disabled for regular DoH queries, accepting them is required to be compatible with ODoH relays.
 
 This can be achieved with the `--allow-odoh-post` command-line switch.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,7 @@ pub const LISTEN_ADDRESS: &str = "127.0.0.1:3000";
 pub const MAX_CLIENTS: usize = 512;
 pub const MAX_CONCURRENT_STREAMS: u32 = 16;
 pub const PATH: &str = "/dns-query";
+#[cfg(feature = "odoh-proxy")]
 pub const ODOH_PROXY_PATH: &str = "/proxy";
 pub const ODOH_CONFIGS_PATH: &str = "/.well-known/odohconfigs";
 pub const SERVER_ADDRESS: &str = "9.9.9.9:53";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,7 @@ pub const LISTEN_ADDRESS: &str = "127.0.0.1:3000";
 pub const MAX_CLIENTS: usize = 512;
 pub const MAX_CONCURRENT_STREAMS: u32 = 16;
 pub const PATH: &str = "/dns-query";
+pub const ODOH_PROXY_PATH: &str = "/proxy";
 pub const ODOH_CONFIGS_PATH: &str = "/.well-known/odohconfigs";
 pub const SERVER_ADDRESS: &str = "9.9.9.9:53";
 pub const TIMEOUT_SEC: u64 = 10;

--- a/src/libdoh/Cargo.toml
+++ b/src/libdoh/Cargo.toml
@@ -25,8 +25,10 @@ hpke = "0.5.1"
 hyper = { version = "0.14.11", default-features = false, features = ["server", "http1", "http2", "stream"] }
 odoh-rs = "1.0.0-alpha.1"
 rand = "0.8.4"
+reqwest = {version = "0.11.4", features = ["trust-dns"]}
 tokio = { version = "1.10.0", features = ["net", "rt-multi-thread", "parking_lot", "time", "sync"] }
 tokio-rustls = { version = "0.22.0", features = ["early-data"], optional = true }
+urlencoding = "2.1.0"
 
 [profile.release]
 codegen-units = 1

--- a/src/libdoh/Cargo.toml
+++ b/src/libdoh/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [features]
 default = ["tls"]
 tls = ["tokio-rustls"]
+odoh-proxy = ["reqwest", "urlencoding"]
 
 [dependencies]
 anyhow = "1.0.42"
@@ -25,10 +26,10 @@ hpke = "0.5.1"
 hyper = { version = "0.14.11", default-features = false, features = ["server", "http1", "http2", "stream"] }
 odoh-rs = "1.0.0-alpha.1"
 rand = "0.8.4"
-reqwest = {version = "0.11.4", features = ["trust-dns"]}
+reqwest = { version = "0.11.4", features = ["trust-dns"], optional = true}
 tokio = { version = "1.10.0", features = ["net", "rt-multi-thread", "parking_lot", "time", "sync"] }
 tokio-rustls = { version = "0.22.0", features = ["early-data"], optional = true }
-urlencoding = "2.1.0"
+urlencoding = { version = "2.1.0", optional = true }
 
 [profile.release]
 codegen-units = 1

--- a/src/libdoh/src/constants.rs
+++ b/src/libdoh/src/constants.rs
@@ -1,4 +1,6 @@
 pub const DNS_QUERY_PARAM: &str = "dns";
+pub const ODOH_TARGET_HOST_QUERY_PARAM: &str = "targethost";
+pub const ODOH_TARGET_PATH_QUERY_PARAM: &str = "targetpath";
 pub const MAX_DNS_QUESTION_LEN: usize = 512;
 pub const MAX_DNS_RESPONSE_LEN: usize = 4096;
 pub const MIN_DNS_PACKET_LEN: usize = 17;

--- a/src/libdoh/src/constants.rs
+++ b/src/libdoh/src/constants.rs
@@ -1,5 +1,7 @@
 pub const DNS_QUERY_PARAM: &str = "dns";
+#[cfg(feature = "odoh-proxy")]
 pub const ODOH_TARGET_HOST_QUERY_PARAM: &str = "targethost";
+#[cfg(feature = "odoh-proxy")]
 pub const ODOH_TARGET_PATH_QUERY_PARAM: &str = "targetpath";
 pub const MAX_DNS_QUESTION_LEN: usize = 512;
 pub const MAX_DNS_RESPONSE_LEN: usize = 4096;

--- a/src/libdoh/src/errors.rs
+++ b/src/libdoh/src/errors.rs
@@ -1,5 +1,6 @@
 use hyper::StatusCode;
 use std::io;
+#[cfg(feature = "odoh-proxy")]
 use reqwest;
 
 #[derive(Debug)]
@@ -11,6 +12,7 @@ pub enum DoHError {
     UpstreamTimeout,
     StaleKey,
     Hyper(hyper::Error),
+    #[cfg(feature = "odoh-proxy")]
     Reqwest(reqwest::Error),
     Io(io::Error),
     ODoHConfigError(anyhow::Error),
@@ -29,6 +31,7 @@ impl std::fmt::Display for DoHError {
             DoHError::UpstreamTimeout => write!(fmt, "Upstream timeout"),
             DoHError::StaleKey => write!(fmt, "Stale key material"),
             DoHError::Hyper(e) => write!(fmt, "HTTP error: {}", e),
+            #[cfg(feature = "odoh-proxy")]
             DoHError::Reqwest(e) => write!(fmt, "HTTP Proxy error: {}", e),
             DoHError::Io(e) => write!(fmt, "IO error: {}", e),
             DoHError::ODoHConfigError(e) => write!(fmt, "ODoH config error: {}", e),
@@ -47,6 +50,7 @@ impl From<DoHError> for StatusCode {
             DoHError::UpstreamTimeout => StatusCode::BAD_GATEWAY,
             DoHError::StaleKey => StatusCode::UNAUTHORIZED,
             DoHError::Hyper(_) => StatusCode::SERVICE_UNAVAILABLE,
+            #[cfg(feature = "odoh-proxy")]
             DoHError::Reqwest(_) => StatusCode::SERVICE_UNAVAILABLE,
             DoHError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
             DoHError::ODoHConfigError(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/libdoh/src/errors.rs
+++ b/src/libdoh/src/errors.rs
@@ -1,5 +1,6 @@
 use hyper::StatusCode;
 use std::io;
+use reqwest;
 
 #[derive(Debug)]
 pub enum DoHError {
@@ -10,6 +11,7 @@ pub enum DoHError {
     UpstreamTimeout,
     StaleKey,
     Hyper(hyper::Error),
+    Reqwest(reqwest::Error),
     Io(io::Error),
     ODoHConfigError(anyhow::Error),
     TooManyTcpSessions,
@@ -27,6 +29,7 @@ impl std::fmt::Display for DoHError {
             DoHError::UpstreamTimeout => write!(fmt, "Upstream timeout"),
             DoHError::StaleKey => write!(fmt, "Stale key material"),
             DoHError::Hyper(e) => write!(fmt, "HTTP error: {}", e),
+            DoHError::Reqwest(e) => write!(fmt, "HTTP Proxy error: {}", e),
             DoHError::Io(e) => write!(fmt, "IO error: {}", e),
             DoHError::ODoHConfigError(e) => write!(fmt, "ODoH config error: {}", e),
             DoHError::TooManyTcpSessions => write!(fmt, "Too many TCP sessions"),
@@ -44,6 +47,7 @@ impl From<DoHError> for StatusCode {
             DoHError::UpstreamTimeout => StatusCode::BAD_GATEWAY,
             DoHError::StaleKey => StatusCode::UNAUTHORIZED,
             DoHError::Hyper(_) => StatusCode::SERVICE_UNAVAILABLE,
+            DoHError::Reqwest(_) => StatusCode::SERVICE_UNAVAILABLE,
             DoHError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
             DoHError::ODoHConfigError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             DoHError::TooManyTcpSessions => StatusCode::SERVICE_UNAVAILABLE,

--- a/src/libdoh/src/globals.rs
+++ b/src/libdoh/src/globals.rs
@@ -1,4 +1,5 @@
 use crate::odoh::ODoHRotator;
+use crate::odoh_proxy::ODoHProxy;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -20,6 +21,7 @@ pub struct Globals {
     pub local_bind_address: SocketAddr,
     pub server_address: SocketAddr,
     pub path: String,
+    pub odoh_proxy_path: String,
     pub max_clients: usize,
     pub timeout: Duration,
     pub clients_count: ClientsCount,
@@ -32,6 +34,7 @@ pub struct Globals {
     pub allow_odoh_post: bool,
     pub odoh_configs_path: String,
     pub odoh_rotator: Arc<ODoHRotator>,
+    pub odoh_proxy: ODoHProxy,
 
     pub runtime_handle: runtime::Handle,
 }

--- a/src/libdoh/src/globals.rs
+++ b/src/libdoh/src/globals.rs
@@ -1,4 +1,5 @@
 use crate::odoh::ODoHRotator;
+#[cfg(feature = "odoh-proxy")]
 use crate::odoh_proxy::ODoHProxy;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -21,7 +22,6 @@ pub struct Globals {
     pub local_bind_address: SocketAddr,
     pub server_address: SocketAddr,
     pub path: String,
-    pub odoh_proxy_path: String,
     pub max_clients: usize,
     pub timeout: Duration,
     pub clients_count: ClientsCount,
@@ -34,6 +34,11 @@ pub struct Globals {
     pub allow_odoh_post: bool,
     pub odoh_configs_path: String,
     pub odoh_rotator: Arc<ODoHRotator>,
+
+    #[cfg(feature = "odoh-proxy")]
+    pub odoh_proxy_path: String,
+
+    #[cfg(feature = "odoh-proxy")]
     pub odoh_proxy: ODoHProxy,
 
     pub runtime_handle: runtime::Handle,

--- a/src/libdoh/src/odoh_proxy.rs
+++ b/src/libdoh/src/odoh_proxy.rs
@@ -1,0 +1,58 @@
+use crate::errors::DoHError;
+use hyper::http::StatusCode;
+use reqwest::header;
+
+#[derive(Debug, Clone)]
+pub struct ODoHProxy {
+  client: reqwest::Client,
+}
+
+impl ODoHProxy {
+  pub fn new(timeout: std::time::Duration) -> Result<Self, DoHError> {
+    // build client
+    let mut headers = header::HeaderMap::new();
+    let ct = "application/oblivious-dns-message";
+    headers.insert("Accept", header::HeaderValue::from_str(&ct).unwrap());
+    headers.insert("Content-Type", header::HeaderValue::from_str(&ct).unwrap());
+    headers.insert(
+      "Cache-Control",
+      header::HeaderValue::from_str("no-cache, no-store").unwrap(),
+    );
+
+    let client = reqwest::Client::builder()
+      .user_agent(format!("odoh-proxy/{}", env!("CARGO_PKG_VERSION")))
+      .timeout(timeout)
+      .trust_dns(true)
+      .default_headers(headers)
+      .build()
+      .map_err(|e| DoHError::Reqwest(e))?;
+
+    Ok(ODoHProxy { client })
+  }
+
+  pub async fn forward_to_target(
+    &self,
+    encrypted_query: &Vec<u8>,
+    target_uri: &str,
+  ) -> Result<Vec<u8>, StatusCode> {
+    // Only post method is allowed in ODoH
+    let response = self
+      .client
+      .post(target_uri)
+      .body(encrypted_query.clone())
+      .send()
+      .await
+      .map_err(|e| {
+        eprintln!("[ODoH Proxy] Upstream query error: {}", e);
+        DoHError::Reqwest(e)
+      })?;
+
+    if response.status() != reqwest::StatusCode::OK {
+      eprintln!("[ODoH Proxy] Response not ok: {:?}", response.status());
+      return Err(response.status());
+    }
+
+    let body = response.bytes().await.map_err(|e| DoHError::Reqwest(e))?;
+    Ok(body.to_vec())
+  }
+}

--- a/src/libdoh/src/odoh_proxy.rs
+++ b/src/libdoh/src/odoh_proxy.rs
@@ -1,58 +1,89 @@
+use crate::constants::*;
 use crate::errors::DoHError;
 use hyper::http::StatusCode;
 use reqwest::header;
+use urlencoding::decode;
+
+pub fn target_uri_from_query_string(http_query: &str) -> Option<String> {
+    let mut targethost = None;
+    let mut targetpath = None;
+    for parts in http_query.split('&') {
+        let mut kv = parts.split('=');
+        if let Some(k) = kv.next() {
+            match k {
+                ODOH_TARGET_HOST_QUERY_PARAM => {
+                    targethost = kv.next().map(str::to_string);
+                }
+                ODOH_TARGET_PATH_QUERY_PARAM => {
+                    targetpath = kv.next().map(str::to_string);
+                }
+                _ => (),
+            }
+        }
+    }
+    if let (Some(host), Some(path)) = (targethost, targetpath) {
+        // remove percent encoding
+        Some(
+            decode(&format!("https://{}{}", host, path))
+                .unwrap_or(std::borrow::Cow::Borrowed(""))
+                .to_string(),
+        )
+    } else {
+        None
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ODoHProxy {
-  client: reqwest::Client,
+    client: reqwest::Client,
 }
 
 impl ODoHProxy {
-  pub fn new(timeout: std::time::Duration) -> Result<Self, DoHError> {
-    // build client
-    let mut headers = header::HeaderMap::new();
-    let ct = "application/oblivious-dns-message";
-    headers.insert("Accept", header::HeaderValue::from_str(&ct).unwrap());
-    headers.insert("Content-Type", header::HeaderValue::from_str(&ct).unwrap());
-    headers.insert(
-      "Cache-Control",
-      header::HeaderValue::from_str("no-cache, no-store").unwrap(),
-    );
+    pub fn new(timeout: std::time::Duration) -> Result<Self, DoHError> {
+        // build client
+        let mut headers = header::HeaderMap::new();
+        let ct = "application/oblivious-dns-message";
+        headers.insert("Accept", header::HeaderValue::from_str(&ct).unwrap());
+        headers.insert("Content-Type", header::HeaderValue::from_str(&ct).unwrap());
+        headers.insert(
+            "Cache-Control",
+            header::HeaderValue::from_str("no-cache, no-store").unwrap(),
+        );
 
-    let client = reqwest::Client::builder()
-      .user_agent(format!("odoh-proxy/{}", env!("CARGO_PKG_VERSION")))
-      .timeout(timeout)
-      .trust_dns(true)
-      .default_headers(headers)
-      .build()
-      .map_err(|e| DoHError::Reqwest(e))?;
+        let client = reqwest::Client::builder()
+            .user_agent(format!("odoh-proxy/{}", env!("CARGO_PKG_VERSION")))
+            .timeout(timeout)
+            .trust_dns(true)
+            .default_headers(headers)
+            .build()
+            .map_err(|e| DoHError::Reqwest(e))?;
 
-    Ok(ODoHProxy { client })
-  }
-
-  pub async fn forward_to_target(
-    &self,
-    encrypted_query: &Vec<u8>,
-    target_uri: &str,
-  ) -> Result<Vec<u8>, StatusCode> {
-    // Only post method is allowed in ODoH
-    let response = self
-      .client
-      .post(target_uri)
-      .body(encrypted_query.clone())
-      .send()
-      .await
-      .map_err(|e| {
-        eprintln!("[ODoH Proxy] Upstream query error: {}", e);
-        DoHError::Reqwest(e)
-      })?;
-
-    if response.status() != reqwest::StatusCode::OK {
-      eprintln!("[ODoH Proxy] Response not ok: {:?}", response.status());
-      return Err(response.status());
+        Ok(ODoHProxy { client })
     }
 
-    let body = response.bytes().await.map_err(|e| DoHError::Reqwest(e))?;
-    Ok(body.to_vec())
-  }
+    pub async fn forward_to_target(
+        &self,
+        encrypted_query: &Vec<u8>,
+        target_uri: &str,
+    ) -> Result<Vec<u8>, StatusCode> {
+        // Only post method is allowed in ODoH
+        let response = self
+            .client
+            .post(target_uri)
+            .body(encrypted_query.clone())
+            .send()
+            .await
+            .map_err(|e| {
+                eprintln!("[ODoH Proxy] Upstream query error: {}", e);
+                DoHError::Reqwest(e)
+            })?;
+
+        if response.status() != reqwest::StatusCode::OK {
+            eprintln!("[ODoH Proxy] Response not ok: {:?}", response.status());
+            return Err(response.status());
+        }
+
+        let body = response.bytes().await.map_err(|e| DoHError::Reqwest(e))?;
+        Ok(body.to_vec())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use libdoh::*;
 use crate::config::*;
 use crate::constants::*;
 
+use libdoh::odoh_proxy::ODoHProxy;
 use libdoh::odoh::ODoHRotator;
 use libdoh::reexports::tokio;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -40,6 +41,7 @@ fn main() {
         local_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
         server_address: SERVER_ADDRESS.parse().unwrap(),
         path: PATH.to_string(),
+        odoh_proxy_path: ODOH_PROXY_PATH.to_string(),
         max_clients: MAX_CLIENTS,
         timeout: Duration::from_secs(TIMEOUT_SEC),
         clients_count: Default::default(),
@@ -52,6 +54,7 @@ fn main() {
         allow_odoh_post: false,
         odoh_configs_path: ODOH_CONFIGS_PATH.to_string(),
         odoh_rotator: Arc::new(rotator),
+        odoh_proxy: ODoHProxy::new(Duration::from_secs(TIMEOUT_SEC)).unwrap(),
 
         runtime_handle: runtime.handle().clone(),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,9 @@ use libdoh::*;
 use crate::config::*;
 use crate::constants::*;
 
+#[cfg(feature = "odoh-proxy")]
 use libdoh::odoh_proxy::ODoHProxy;
+
 use libdoh::odoh::ODoHRotator;
 use libdoh::reexports::tokio;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -41,7 +43,6 @@ fn main() {
         local_bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
         server_address: SERVER_ADDRESS.parse().unwrap(),
         path: PATH.to_string(),
-        odoh_proxy_path: ODOH_PROXY_PATH.to_string(),
         max_clients: MAX_CLIENTS,
         timeout: Duration::from_secs(TIMEOUT_SEC),
         clients_count: Default::default(),
@@ -54,6 +55,10 @@ fn main() {
         allow_odoh_post: false,
         odoh_configs_path: ODOH_CONFIGS_PATH.to_string(),
         odoh_rotator: Arc::new(rotator),
+
+        #[cfg(feature = "odoh-proxy")]
+        odoh_proxy_path: ODOH_PROXY_PATH.to_string(),
+        #[cfg(feature = "odoh-proxy")]
         odoh_proxy: ODoHProxy::new(Duration::from_secs(TIMEOUT_SEC)).unwrap(),
 
         runtime_handle: runtime.handle().clone(),


### PR DESCRIPTION
Hello!

Much like `encrypted-dns-server` having both target resolver and relay functions, I have added the Oblivious Proxy function of ODoH in `doh-server`. I am not sure if this is a right direction of DNSCrypt community, but I believe it is useful. I am very happy If you like this extension and review it.

The relaying logic exactly follows the current Cloudflare's implementation in Golang. (https://github.com/cloudflare/odoh-server-go)

Note: In the IETF-draft (ver.6, Mar. 2021), single endpoint (e.g., `/dns-query`) works as both oblivious target and proxy, and only requests with appropriate uri queries are forwarded to oblivious target. But in the current Cloudflare's implementation, each of proxy and target has a distinct endpoint. Only requests to the proxy-specific endpoint (e.g., `/proxy`) are always handled as ones forwarded upstream, and the endpoint of `/dns-query` does not forward incoming requests.